### PR TITLE
address some more warnings

### DIFF
--- a/src/dns_plugin.plug
+++ b/src/dns_plugin.plug
@@ -84,7 +84,7 @@ udp_start = PLD->PL_info.IP_len;
 len=PLD->PL_info.IP_len + PLD->PL_info.UDP_len + PLD->PL_info.DATA_len;
 dns_iphead= (struct IP_header *) dns_buffer;
 dns_udphead= (struct UDP_header *) (dns_buffer+udp_start);
-dns_dnshead= (struct DNS_header *) (dns_buffer+udp_start+sizeof(struct UDP_header));
+dns_dnshead= (struct PL_DNS_header *) (dns_buffer+udp_start+sizeof(struct UDP_header));
 
 PL_pos_max = PLD->PL_info.DATA_len - 12;
 

--- a/src/sn_analyse.c
+++ b/src/sn_analyse.c
@@ -10,7 +10,7 @@ if(status==0)                        /* make a new entry unless it's reset */
   {
   if(finish!=TCP_FINISH)
     if((dummy_pointer=add_dynam(filename, TCP, 0,ntohl(tcphead.seq_nr),info.DATA_len))==NULL)
-	return 1;
+	return;
   };
 
 if(finish==TCP_FINISH)                      /* let's reset the connection */
@@ -26,7 +26,7 @@ if(LOGPARAM & LOGPARAM_RAW)          /* Raw logging */
   if(dummy&SYN)	print_conn(filename,"Connection initiated. (SYN)");
   if(dummy&FIN) print_conn(filename,"Connection ending. (FIN)");
   if(dummy&RST) print_conn(filename,"Connection reset. (RST)");
-  return 1;
+  return;
   };
 
 data = sp+PROTO_HEAD+info.IP_len+info.TCP_len;
@@ -40,7 +40,7 @@ if(LOGPARAM & LOGPARAM_NORM)          /* NORM logging */
     };
   };
 
-if((dummy&FIN)||(dummy&RST)) return 1; /* needed, cauz entry don't exist  */
+if((dummy&FIN)||(dummy&RST)) return; /* needed, cauz entry don't exist  */
 
 /*** TELNET *****************************************************************/
 if(LOGPARAM & LOGPARAM_TELNET)
@@ -197,5 +197,5 @@ if( (dummy_pointer=search_dynam(filename, TCP)) !=NULL)
   if(ntohl(tcphead.seq_nr)>dummy_pointer->exp_seq)
     dummy_pointer->exp_seq=ntohl(tcphead.seq_nr)+info.DATA_len;
   }
-return 1;
-return 1;  /* DON'T FORGET THEM!!!! */
+return;
+return;  /* DON'T FORGET THEM!!!! */

--- a/src/sn_cfgfile.c
+++ b/src/sn_cfgfile.c
@@ -30,7 +30,7 @@ extern int Priority;        /* The higher the priority, the more important */
 extern char dot_notation[20];                       /* for easy working, Q&D */
 extern char Logfile[250];
 
-void clear_list_buffer (struct cfg_file_contense *help)
+static void clear_list_buffer (struct cfg_file_contense *help)
 {
 help->host[0]=0;
 help->priority=0;
@@ -38,7 +38,7 @@ help->port=0;
 help->wildcard=0;
 }
 
-struct cfg_file_contense *adjust_select_from_list (void)
+static struct cfg_file_contense *adjust_select_from_list (void)
 {
 Priority++;
 select_from_length++;
@@ -57,7 +57,7 @@ clear_list_buffer(&(select_from_list[select_from_length-1]));
 return &(select_from_list[select_from_length-1]);
 }
 
-struct cfg_file_contense *adjust_select_to_list (void)
+static struct cfg_file_contense *adjust_select_to_list (void)
 {
 Priority++;
 select_to_length++;
@@ -77,7 +77,7 @@ clear_list_buffer(&(select_to_list[select_to_length-1]));
 return &(select_to_list[select_to_length-1]);
 }
 
-struct cfg_file_contense *adjust_deselect_from_list (void)
+static struct cfg_file_contense *adjust_deselect_from_list (void)
 {
 Priority++;
 deselect_from_length++;
@@ -96,7 +96,7 @@ clear_list_buffer(&(deselect_from_list[deselect_from_length-1]));
 return (&(deselect_from_list[deselect_from_length-1]));
 }
 
-struct cfg_file_contense *adjust_deselect_to_list (void)
+static struct cfg_file_contense *adjust_deselect_to_list (void)
 {
 Priority++;
 deselect_to_length++;
@@ -116,7 +116,7 @@ clear_list_buffer(&(deselect_to_list[deselect_to_length-1]));
 return &(deselect_to_list[deselect_to_length-1]);
 }
 
-char *clean_string (char *string)
+static char *clean_string (char *string)
 {
 char help[20];
 int i, j;
@@ -140,7 +140,7 @@ strcpy(string, help);
 return string;
 }
 
-char *clean_filename (char *string)
+static char *clean_filename (char *string)
 {
 char help[20];
 int i, j;
@@ -164,7 +164,7 @@ strcpy(string, help);
 return string;
 }
 
-void make_nr_dot (char *host)
+static void make_nr_dot (char *host)
 {
 _32_bit hostnr;
 unsigned char *digit;
@@ -208,7 +208,7 @@ if (ret <= 0)
 return ret;
 }
 
-void interprete_line (char *line)
+static void interprete_line (char *line)
 {
 struct cfg_file_contense *help, *helpp;
 char *field;

--- a/src/sn_cfgfile.h
+++ b/src/sn_cfgfile.h
@@ -1,12 +1,3 @@
 /* Sniffit Config File include                                                          */
 
-void clear_list_buffer (struct cfg_file_contense *);
-struct cfg_file_contense *adjust_select_from_list (void);
-struct cfg_file_contense *adjust_select_to_list (void);
-struct cfg_file_contense *adjust_deselect_from_list (void);
-struct cfg_file_contense *adjust_deselect_to_list (void);
-char *clean_string (char *);
-char *clean_filename (char *);
-void make_nr_dot (char *);
-void interprete_line (char *);
-void read_cfg_file (char *);
+extern void read_cfg_file (char *);

--- a/src/sn_config.h
+++ b/src/sn_config.h
@@ -85,7 +85,7 @@
 /* #define	DEBUG_ONSCREEN */
 
 #ifdef DEBUG
-void close_debug_device (void);
-void debug_msg(char *);
+extern void close_debug_device (void);
+extern void debug_msg(char *);
 #endif
 

--- a/src/sn_generation.c
+++ b/src/sn_generation.c
@@ -19,6 +19,13 @@
 
 extern volatile int screen_busy;
 
+/*** forward declarations ***/
+static void transmit_UDP (int, char *,
+			   int, int,
+		           _32_bit, unsigned short,
+			   _32_bit, unsigned short);
+static int open_sending (void);
+
 void exec_generate(struct generate_mask *generate)
 {
 WINDOW *Msg_dsp;
@@ -126,7 +133,7 @@ forced_refresh();
 #define SP_UDP_HEAD_BASE 	8              /* Always fixed */
 
 
-int open_sending (void)
+static int open_sending (void)
 {
 struct protoent *sp_proto;
 int sp_fd;
@@ -142,7 +149,7 @@ if ((sp_fd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW))==-1)
 return sp_fd;
 }
 
-void sp_send_packet (struct sp_data_exchange *sp, unsigned char proto)
+static void sp_send_packet (struct sp_data_exchange *sp, unsigned char proto)
 {
 int sp_status;
 struct sockaddr_in sp_server;
@@ -182,7 +189,7 @@ if (sp_status < 0 || sp_status != sp->datalen+HEAD_BASE+SP_IP_HEAD_BASE+sp->IP_o
 #endif
 }
 
-void sp_fix_IP_packet (struct sp_data_exchange *sp, unsigned char proto)
+static void sp_fix_IP_packet (struct sp_data_exchange *sp, unsigned char proto)
 {
 struct IP_header *sp_help_ip;
 int HEAD_BASE;
@@ -211,7 +218,7 @@ sp_help_ip->checksum=in_cksum((unsigned short *) (sp->buffer),
 #endif
 }
 
-void sp_fix_TCP_packet (struct sp_data_exchange *sp)
+static void sp_fix_TCP_packet (struct sp_data_exchange *sp)
 {
 char sp_pseudo_ip_construct[MTU];
 struct TCP_header *sp_help_tcp;
@@ -245,7 +252,8 @@ sp_help_tcp->checksum=in_cksum((unsigned short *) sp_pseudo_ip_construct,
 #endif
 }
 
-void transmit_TCP (int sp_fd, char *sp_data,
+/* FIXME: dead code */
+static void transmit_TCP (int sp_fd, char *sp_data,
 			   int sp_ipoptlen, int sp_tcpoptlen, int sp_datalen,
 		           _32_bit sp_source, unsigned short sp_source_port,
 			   _32_bit sp_dest, unsigned short sp_dest_port,
@@ -285,7 +293,7 @@ sp_fix_IP_packet(&sp_struct, 6);
 sp_send_packet(&sp_struct, 6);
 }
 
-void sp_fix_UDP_packet (struct sp_data_exchange *sp)
+static void sp_fix_UDP_packet (struct sp_data_exchange *sp)
 {
 char sp_pseudo_ip_construct[MTU];
 struct UDP_header *sp_help_udp;
@@ -316,7 +324,7 @@ sp_help_udp->checksum=in_cksum((unsigned short *) sp_pseudo_ip_construct,
 #endif
 }
 
-void transmit_UDP (int sp_fd, char *sp_data,
+static void transmit_UDP (int sp_fd, char *sp_data,
 			   int sp_ipoptlen, int sp_datalen,
 		           _32_bit sp_source, unsigned short sp_source_port,
 			   _32_bit sp_dest, unsigned short sp_dest_port)

--- a/src/sn_generation.h
+++ b/src/sn_generation.h
@@ -1,22 +1,3 @@
 /* Sniffit Packet Generation File                                         */
 
-void exec_generate(struct generate_mask *);
-
-void transmit_TCP (int, char *,
-		     	   int, int , int ,
-		           _32_bit, unsigned short,
-			   _32_bit, unsigned short,
-                           _32_bit, _32_bit,
-                           unsigned short);
-
-void transmit_UDP (int, char *,
-			   int, int,
-		           _32_bit, unsigned short,
-			   _32_bit, unsigned short);
-
-int open_sending (void);
-
-void sp_send_packet (struct sp_data_exchange *, unsigned char);
-void sp_fix_TCP_packet (struct sp_data_exchange *);
-void sp_fix_UDP_packet (struct sp_data_exchange *);
-void sp_fix_IP_packet (struct sp_data_exchange *, unsigned char);
+extern void exec_generate(struct generate_mask *);

--- a/src/sn_interface.c
+++ b/src/sn_interface.c
@@ -52,8 +52,13 @@ extern int INFO_WINDOW_X, INFO_WINDOW_Y, MASK_WINDOW_X, MASK_WINDOW_Y;
 extern int DATA_WINDOW_X, DATA_WINDOW_Y;
 
 
+/*** forward declarations ***/
+static void stop_logging (void);
+static void screen_exit (void);
+
+
 /*** Sreen operations ***/
-void init_screen (void)
+static void init_screen (void)
 {
 initscr();
 cbreak();
@@ -90,7 +95,7 @@ if( (COLS<80)||(LINES<18) )
 	exit(0);
 };
 
-void f_box_window (struct box_window *Win,
+static void f_box_window (struct box_window *Win,
                  int num_lines, int num_cols, int begy,int begx, int col_mode)
 /*  col_mode : color selection   */
 {
@@ -126,7 +131,7 @@ wnoutrefresh(Win->main_window);wnoutrefresh(Win->work_window);
 doupdate();
 }
 
-void data_window (struct box_window *Win, struct box_window *P_Win,
+static void data_window (struct box_window *Win, struct box_window *P_Win,
                  int num_lines, int num_cols, int begy,int begx,
                  char *buffer, int listitem)
 {
@@ -164,7 +169,7 @@ wnoutrefresh(Win->main_window);wnoutrefresh(Win->work_window);
 doupdate();
 }
 
-void data_device (char *buffer, int listitem)
+static void data_device (char *buffer, int listitem)
 {
 int i=0, j=0;
 struct shared_conn_data *conn;
@@ -182,7 +187,7 @@ if(i>=CONNECTION_CAPACITY+1) return;
 strcpy(log_conn->log_enter, conn[i].connection);
 }
 
-void mask_status (struct box_window *Work_win)
+static void mask_status (struct box_window *Work_win)
 {
 unsigned char *ad;
 int i;
@@ -218,7 +223,7 @@ wnoutrefresh(Work_win->work_window);
 doupdate();
 }
 
-void fill_box_window (struct box_window *Work_win, char *buffer,
+static void fill_box_window (struct box_window *Work_win, char *buffer,
                       int begin_item, int boxlen, int rowlen)
                                                  /* 0 is the first item  */
 {
@@ -269,7 +274,7 @@ for(i=line;i<boxlen;i++)
 wnoutrefresh(Work_win->work_window);
 }
 
-void point_item (struct box_window *Work_win, char *buffer,
+static void point_item (struct box_window *Work_win, char *buffer,
                  int item, int begin_item, int boxlen, int rowlen)
 {
 int i=0, j=0;
@@ -361,7 +366,7 @@ if(PACKET_INFO==1)
 doupdate();
 }
 
-void menu_line (void)
+static void menu_line (void)
 {
 int i;
 
@@ -412,7 +417,7 @@ char *input_field(char *string, char *input, int flag)
 	return input;
 }
 
-void exec_mask (void)
+static void exec_mask (void)
 {
 LISTpos=0;
 POINTpos=-1;             /* otherwise we get never ending loop */
@@ -424,7 +429,7 @@ forced_refresh();
 
 /* signaling */
 
-void sig_blocking(char on_off, int sig)
+static void sig_blocking(char on_off, int sig)
 {
 sigset_t set;
 
@@ -434,7 +439,7 @@ if(on_off==1)
 else	{sigprocmask(SIG_UNBLOCK,&set,NULL);}
 }
 
-void set_signal (int signum, sig_hand new_action)
+static void set_signal (int signum, sig_hand new_action)
 {
 struct sigaction new_sigusr;
 sigset_t sig_mask;
@@ -448,7 +453,7 @@ new_sigusr.sa_flags=0;
 sigaction(signum,&new_sigusr,NULL);
 }
 
-void interaction (int sig)              /* invoked when data arrives */
+static void interaction (int sig)              /* invoked when data arrives */
 {
 int i;
 struct shared_conn_data *conn;
@@ -483,7 +488,7 @@ forced_refresh();
 set_signal(SIGUSR1,interaction);
 }
 
-void packet_info_handler (int signum)
+static void packet_info_handler (int signum)
 {
 #ifdef DEBUG
 		debug_msg("ALARM RANG");
@@ -515,7 +520,7 @@ void child_exit (void)
 kill(Pid,SIGKILL);
 };
 
-void screen_exit (void)
+static void screen_exit (void)
 {
 endwin();
 /* next line added by Edward Betts <edward@debian.org>, should not be needed
@@ -532,7 +537,7 @@ if(shmctl(memory_id,IPC_RMID,0)<0)
 
 /* Some other stuff */
 
-void stop_logging (void)
+static void stop_logging (void)
 {
 LOGGING=0;
 log_conn->log_enter[0]=0;
@@ -541,7 +546,7 @@ if(logging_device==NULL)
 forced_refresh();
 }
 
-void stop_packet_info (void)
+static void stop_packet_info (void)
 {
 PACKET_INFO=0;
 alarm(0);
@@ -640,7 +645,7 @@ for(i=0;i<CONNECTION_CAPACITY;i++)
 *timing=0;
 };
 
-void create_arguments(char *esource, char *es_port, char *edest,
+static void create_arguments(char *esource, char *es_port, char *edest,
 				        char *ed_port, char *buffer, int item)
 {
 char e_dummy[CONN_NAMELEN];

--- a/src/sn_interface.h
+++ b/src/sn_interface.h
@@ -4,33 +4,11 @@
 
 typedef void (*sig_hand)(int );  /* sighandler_t gave errors, weird */
 
-int add_itemlist(char *, char *, char *);
-void child_exit (void);
-void clear_shared_mem(char);
-void data_device (char *, int);
-void data_window (struct box_window *, struct box_window *, int, int, int,
-						    	       int, char *, int);
-int del_itemlist(char *, char *);
-void exec_mask (void);
-void f_box_window (struct box_window *, int, int, int, int, int);
-void fill_box_window (struct box_window *, char *, int, int, int);
-void forced_refresh (void);
-void init_screen (void);
-char *input_field(char *, char *, int);
-void interaction (int);
-void mask_status (struct box_window *);
-void mem_exit (void);
-void menu_line (void);
-void point_item (struct box_window *, char *, int, int, int, int);
-void run_interface (void);
-void screen_exit (void);
-void set_signal (int, sig_hand);
-void sig_blocking(char, int);
-void stop_logging (void);
-int check_mask (const struct packetheader *,const unsigned char *, char *,
-                                            char *, char *, struct unwrap *);
-pcap_handler interactive_packethandler( char *, const struct packetheader *,
-                 		        const unsigned char *);
-void stop_packet_info (void);
-void packet_info_handler (int);
-void create_arguments(char *, char *, char *, char *, char *, int);
+extern int add_itemlist(char *, char *, char *);
+extern void child_exit (void);
+extern void clear_shared_mem(char);
+extern int del_itemlist(char *, char *);
+extern void forced_refresh (void);
+extern char *input_field(char *, char *, int);
+extern void mem_exit (void);
+extern void run_interface (void);

--- a/src/sn_logfile.c
+++ b/src/sn_logfile.c
@@ -18,7 +18,10 @@ extern FILE *LogFILE;                                     /* logfile stream */
 extern char LOGPARAM;
 extern char DUMPMODE;				   	 /* recorded or not */
 
-void logfile_exit (void)         /* at/on_exit closing of logfile */
+/*** forward declarations ***/
+static void print_logline (char *);
+
+static void logfile_exit (void)         /* at/on_exit closing of logfile */
 {
 printf("Sniffit Logging session ended.\n");
 print_logline("Sniffit session ended.");
@@ -26,7 +29,7 @@ fflush(LogFILE);
 fclose(LogFILE);
 }
 
-char *gettime (void)
+static char *gettime (void)
 {
 time_t t;
 char *tm;
@@ -38,7 +41,7 @@ tm[24]=0;
 return (DUMPMODE&16)?recorded:tm;
 }
 
-void print_logline (char *logline)
+static void print_logline (char *logline)
 {
 fprintf(LogFILE,"[%s] - %s\n",gettime(),logline);
 fflush(LogFILE);

--- a/src/sn_logfile.h
+++ b/src/sn_logfile.h
@@ -7,13 +7,10 @@
 #define	LOG_PWD			3
 #define	LOG_PWD_RECORDED	4
 
-void logfile_exit (void);
-char *gettime (void);
-void print_logline (char *);
-void print_ftp_user (char *, char *);
-void print_ftp_pass(char *, char *);
-void print_login (char *, char *);
-void print_pwd (char *, char *);
-void print_conn (char *, char *);
-void print_mail (char *, char *);
-void open_logfile (void);
+extern void print_ftp_user (char *, char *);
+extern void print_ftp_pass(char *, char *);
+extern void print_login (char *, char *);
+extern void print_pwd (char *, char *);
+extern void print_conn (char *, char *);
+extern void print_mail (char *, char *);
+extern void open_logfile (void);

--- a/src/sn_packets.h
+++ b/src/sn_packets.h
@@ -3,7 +3,7 @@
 #ifndef _SN_PACKETS_H_
 #define _SN_PACKETS_H_
 
-unsigned short in_cksum(unsigned short *,int);
-int unwrap_packet (const unsigned char *, struct unwrap *);
+extern unsigned short in_cksum(unsigned short *,int);
+extern int unwrap_packet (const unsigned char *, struct unwrap *);
 
 #endif

--- a/src/sn_packetstructs.h
+++ b/src/sn_packetstructs.h
@@ -5,13 +5,6 @@
 
 #include <sys/time.h>
 
-struct packetheader
-{
-        struct timeval ts;      /* time stamp */
-        unsigned long caplen;          /* length of portion present */
-        unsigned long len;             /* length this packet (off wire) */
-};
-
 struct IP_header                        /* The IPheader (without options) */
 {
 	unsigned char verlen, type;

--- a/src/sniffit.c
+++ b/src/sniffit.c
@@ -1071,7 +1071,7 @@ if((info->FRAG_nf!=0)||(proto==TCP_FRAG_HEAD))
 }
 
 /* Default Processing of packets */
-static pcap_handler
+static void
 packethandler (unsigned char *ipaddrpoint,
 	       const struct pcap_pkthdr * p_header,
 	       const unsigned char *sp)
@@ -1097,19 +1097,19 @@ packethandler (unsigned char *ipaddrpoint,
   finish = check_packet (ipaddr, p_header, sp, filename, filename2, &info, header, SNIFMODE);
 
   if (finish == DROP_PACKET)
-    return 0;			/* Packet is broken */
+    return;			/* Packet is broken */
 
   if( (PROTOCOLS&F_IP)&&((PROTOCOLS&F_TCP)==0))
     memcpy (&iphead, (sp + PROTO_HEAD), sizeof (struct IP_header)),
       print_iphead (&iphead, 0);
 
   if (finish == DONT_EXAMINE)
-    return 0;			/* Packet is not for us */
+    return;			/* Packet is not for us */
 
   if(DUMPMODE==8)               /* Recording */
     {
     pcap_dump((unsigned char *) dev_dump, p_header, sp);
-    return 1;
+    return;
     }
 
   if((PROTOCOLS & F_IP)&&(PROTOCOLS & F_TCP)&&(finish<10))
@@ -1190,11 +1190,11 @@ packethandler (unsigned char *ipaddrpoint,
 	  if (status == 0)
 	    {
 	      if (finish == TCP_FINISH)
-		return 1;
+		return;
 	      /* there was never data transmitted */
 	      /* seq_nr & datalen not important here yet */
 	      if ((dummy_pointer = add_dynam (filename, TCP, 1, 0, 0)) == NULL)
-		return 1;
+		return;
 	    }
 	  f = dummy_pointer->f;
 
@@ -1260,7 +1260,7 @@ packethandler (unsigned char *ipaddrpoint,
 	  printf ("\nYou mixed incompatible options!\n");
 	  exit (1);
 	}
-      return 1;
+      return;
     }
 
   if ((finish < 10) && (LOGPARAM != 0))		/*  TCP packet - logfile   */
@@ -1340,7 +1340,7 @@ packethandler (unsigned char *ipaddrpoint,
 	  break;
 	}
       printf ("\n");
-      return 1;
+      return;
     }
   if (finish < 30)		/* nothing yet */
     {
@@ -1373,7 +1373,7 @@ packethandler (unsigned char *ipaddrpoint,
 	  printf ("\nImpossible error! Sniffer Heartattack!\n");
 	  exit (0);
 	}
-      return 1;
+      return;
     }
 }
 
@@ -1471,8 +1471,8 @@ if(INTERACTIVE_EXTEND==1)
   return TCP_EXAMINE;		/* interprete packet */
 }
 
-static pcap_handler
-interactive_packethandler (char *dummy,
+static void
+interactive_packethandler (unsigned char *dummy,
 			   const struct pcap_pkthdr * p_header,
 			   const unsigned char *sp)
 {
@@ -1486,9 +1486,9 @@ interactive_packethandler (char *dummy,
 
   finish = check_mask (p_header, sp, conn_name, conn_name2, desc_string, &info);
   if (finish == DROP_PACKET)
-    return 0;			/* Packet is broken */
+    return;			/* Packet is broken */
   if (finish == DONT_EXAMINE)
-    return 0;			/* Packet is not for us */
+    return;			/* Packet is not for us */
 
   if (finish != TCP_FINISH)	/* finish: already logged, or to short to add */
     add_itemlist (running_connections, conn_name, desc_string);

--- a/src/sniffit.c
+++ b/src/sniffit.c
@@ -44,10 +44,13 @@
 
 #include "sniffit.h"		/* definition of functions  */
 
+/*** forward declarations ***/
+static void delete_dynam (char *, char, char);
+
 static char Copyright[] =
 "Sniffit - Brecht Claerhout - Copyright 1996-98";
 
-void quit (char *prog_name)		/* Learn to use the program */
+static void quit (char *prog_name)		/* Learn to use the program */
 {
   printf (
 	   "usage: %s [-xdabvnN] [-P proto] [-A char] [-p port] [(-r|-R) recordfile]\n"
@@ -129,7 +132,7 @@ char *strlower (char *string)
   return string;
 }
 
-void start_plugin (int PL_nr, struct Plugin_data *PL_d)
+static void start_plugin (int PL_nr, struct Plugin_data *PL_d)
 {
   switch (PL_nr)
     {
@@ -195,7 +198,7 @@ void start_plugin (int PL_nr, struct Plugin_data *PL_d)
     }
 }
 
-void
+static void
 reset_all (void)
 {
   start_dynam = NULL;
@@ -204,7 +207,7 @@ reset_all (void)
 
 /* if do_file == 0, then don't handle the files */
 /* this is for the global logfile option        */
-struct file_info *
+static struct file_info *
 add_dynam (char *file, char ptype, char do_file,
 	   _32_bit cur_seq, int len)
 {
@@ -281,7 +284,7 @@ add_dynam (char *file, char ptype, char do_file,
   return dummy_pointer;
 }
 
-void
+static void
 delete_dynam (char *file, char ptype, char do_file)
 {
   struct file_info *search_pointer;
@@ -322,7 +325,7 @@ delete_dynam (char *file, char ptype, char do_file)
 }
 
 /* returns NULL on failure */
-struct file_info *
+static struct file_info *
 search_dynam (char *file, char ptype)
 {
   struct file_info *search_pointer;
@@ -354,7 +357,7 @@ search_dynam (char *file, char ptype)
 }
 
 /* Type 0: TELNET  */
-void
+static void
 record_buf (struct file_info *dummy_pointer, _32_bit cur_seq_nr,
 	    char *data, int len, int type)
 {
@@ -400,7 +403,7 @@ record_buf (struct file_info *dummy_pointer, _32_bit cur_seq_nr,
 #endif
 }
 
-void
+static void
 sb_shift (struct file_info *dummy_pointer)
 {
   int i, j;
@@ -409,7 +412,7 @@ sb_shift (struct file_info *dummy_pointer)
     dummy_pointer->scroll_buf[i - 1] = dummy_pointer->scroll_buf[i];
 }
 
-void
+static void
 sbuf_update (struct file_info *dummy_pointer, _32_bit cur_seq_nr,
 	     char *data, int len)
 {
@@ -439,7 +442,7 @@ sbuf_update (struct file_info *dummy_pointer, _32_bit cur_seq_nr,
 #endif
 }
 
-void
+static void
 print_iphead (struct IP_header *iphead, char icmp_or_plain)
 {
   int dummy;
@@ -474,7 +477,7 @@ print_iphead (struct IP_header *iphead, char icmp_or_plain)
   printf ("\n");
 }
 
-int
+static int
 check_packet (_32_bit ipaddr,
 	      const struct packetheader *p_header,
 	      const unsigned char *sp,
@@ -1068,7 +1071,7 @@ if((info->FRAG_nf!=0)||(proto==TCP_FRAG_HEAD))
 }
 
 /* Default Processing of packets */
-pcap_handler
+static pcap_handler
 packethandler (unsigned char *ipaddrpoint,
 	       const struct packetheader * p_header,
 	       const unsigned char *sp)
@@ -1376,7 +1379,7 @@ packethandler (unsigned char *ipaddrpoint,
 
 
 #ifdef INCLUDE_INTERFACE	/* Interactive packethandling */
-int
+static int
 check_mask (const struct packetheader *p_header,
 	    const unsigned char *sp,
 	    char *conn_name, char *conn_name2, char *desc_string,
@@ -1468,7 +1471,7 @@ if(INTERACTIVE_EXTEND==1)
   return TCP_EXAMINE;		/* interprete packet */
 }
 
-pcap_handler
+static pcap_handler
 interactive_packethandler (char *dummy,
 			   const struct packetheader * p_header,
 			   const unsigned char *sp)

--- a/src/sniffit.c
+++ b/src/sniffit.c
@@ -479,7 +479,7 @@ print_iphead (struct IP_header *iphead, char icmp_or_plain)
 
 static int
 check_packet (_32_bit ipaddr,
-	      const struct packetheader *p_header,
+	      const struct pcap_pkthdr *p_header,
 	      const unsigned char *sp,
 	      char *file,
 	      char *file2,
@@ -1073,7 +1073,7 @@ if((info->FRAG_nf!=0)||(proto==TCP_FRAG_HEAD))
 /* Default Processing of packets */
 static pcap_handler
 packethandler (unsigned char *ipaddrpoint,
-	       const struct packetheader * p_header,
+	       const struct pcap_pkthdr * p_header,
 	       const unsigned char *sp)
 {
   char filename[50], filename2[50], header[SNAPLEN];
@@ -1380,7 +1380,7 @@ packethandler (unsigned char *ipaddrpoint,
 
 #ifdef INCLUDE_INTERFACE	/* Interactive packethandling */
 static int
-check_mask (const struct packetheader *p_header,
+check_mask (const struct pcap_pkthdr *p_header,
 	    const unsigned char *sp,
 	    char *conn_name, char *conn_name2, char *desc_string,
 	    struct unwrap *info)
@@ -1473,7 +1473,7 @@ if(INTERACTIVE_EXTEND==1)
 
 static pcap_handler
 interactive_packethandler (char *dummy,
-			   const struct packetheader * p_header,
+			   const struct pcap_pkthdr * p_header,
 			   const unsigned char *sp)
 {
   char conn_name[CONN_NAMELEN], conn_name2[CONN_NAMELEN];

--- a/src/sniffit.h
+++ b/src/sniffit.h
@@ -6,28 +6,5 @@
 #include "pcap.h"
 
 /**** Sniffit functions *****************************************************/
-int check_packet(_32_bit,
-                const struct packetheader *,
-                const unsigned char *,char *, char *,
-                struct unwrap *,char *,int);
-pcap_handler packethandler(unsigned char *,const struct packetheader *,
-							const unsigned char *);
-int check_mask (const struct packetheader *,const unsigned char *, char *,
-    	                                      char *, char *, struct unwrap *);
-pcap_handler interactive_packethandler( char *, const struct packetheader *,
-                                        const unsigned char *);
-void print_iphead (struct IP_header *, char);
-void quit (char *);
-void reset_all (void);
-char *strlower (char *);
-struct file_info *add_dynam (char *, char, char, _32_bit, int);
-void delete_dynam (char *, char, char);
-void record_buf(struct file_info *, _32_bit, char *, int, int);
-void sb_shift(struct file_info *);
-void sbuf_update(struct file_info *, _32_bit, char *, int);
-struct file_info *search_dynam(char *, char);
-
-/**** Sniffit functions (plugins) *******************************************/
-void start_plugin (int, struct Plugin_data *);
-
+extern char *strlower (char *);
 #endif


### PR DESCRIPTION
These changes apply more clean-ups. Still a number of warnings remain, these mostly stand for using pointers correctly to handle packet data and would require more time to fix one by one. No promises to fix that anytime soon, but at least the problem is smaller now.